### PR TITLE
Removed extra whitespace following heredoc delimiters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ A map describing customer-managed keys to associate with the resource. This incl
 - `key_version` - (Optional) The version of the key. If not specified, the latest version is used.
 - `user_assigned_identity` - (Optional) An object representing a user-assigned identity with the following properties:
   - `resource_id` - The resource ID of the user-assigned identity.
-DESCRIPTION  
+DESCRIPTION
 }
 
 variable "disk_access_id" {


### PR DESCRIPTION
Removed extra whitespace following heredoc delimiters to improve config parsing in certain IDEs

Fixes #97